### PR TITLE
Remove solder paste from negative terminal

### DIFF
--- a/Keystone_3000_1x12mm-CoinCell.kicad_mod
+++ b/Keystone_3000_1x12mm-CoinCell.kicad_mod
@@ -1,4 +1,4 @@
-(module Keystone_3000_1x12mm-CoinCell (layer F.Cu) (tedit 57A5D6FA)
+(module Keystone_3000_1x12mm-CoinCell (layer F.Cu) (tedit 58972371)
   (descr http://www.keyelco.com/product-pdf.cfm?p=777)
   (tags "Keystone type 3000 coin cell retainer")
   (attr smd)
@@ -60,7 +60,7 @@
   (fp_line (start -4 -6.7) (end 4 -6.7) (layer F.Fab) (width 0.15))
   (pad 1 smd rect (at -7.9 0) (size 3.5 3.3) (layers F.Cu F.Paste F.Mask))
   (pad 1 smd rect (at 7.9 0) (size 3.5 3.3) (layers F.Cu F.Paste F.Mask))
-  (pad 2 smd rect (at 0 0) (size 4 4) (layers F.Cu F.Paste F.Mask))
+  (pad 2 smd rect (at 0 0) (size 4 4) (layers F.Cu F.Mask))
   (model Battery_Holders.3dshapes/Keystone_3000_1x12mm-CoinCell.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))

--- a/Keystone_3001_1x12mm-CoinCell.kicad_mod
+++ b/Keystone_3001_1x12mm-CoinCell.kicad_mod
@@ -1,4 +1,4 @@
-(module Keystone_3001_1x12mm-CoinCell (layer F.Cu) (tedit 57A5DD55)
+(module Keystone_3001_1x12mm-CoinCell (layer F.Cu) (tedit 58972363)
   (descr http://www.keyelco.com/product-pdf.cfm?p=778)
   (tags "Keystone type 3001 coin cell retainer")
   (fp_text reference REF*** (at 0 -8) (layer F.SilkS)
@@ -55,7 +55,7 @@
   (fp_line (start -4 -6.7) (end 4 -6.7) (layer F.Fab) (width 0.15))
   (pad 1 thru_hole circle (at -6.6 0) (size 3 3) (drill 1.9) (layers *.Cu *.Mask))
   (pad 1 thru_hole circle (at 6.6 0) (size 3 3) (drill 1.9) (layers *.Cu *.Mask))
-  (pad 2 smd rect (at 0 0) (size 4 4) (layers F.Cu F.Paste F.Mask))
+  (pad 2 smd rect (at 0 0) (size 4 4) (layers F.Cu F.Mask))
   (model Battery_Holders.3dshapes/Keystone_3001_1x12mm-CoinCell.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))

--- a/Keystone_3008_1x2450-CoinCell.kicad_mod
+++ b/Keystone_3008_1x2450-CoinCell.kicad_mod
@@ -1,4 +1,4 @@
-(module Keystone_3008_1x2450-CoinCell (layer F.Cu) (tedit 57AF1160)
+(module Keystone_3008_1x2450-CoinCell (layer F.Cu) (tedit 58972352)
   (descr http://www.keyelco.com/product-pdf.cfm?p=786)
   (tags "Keystone type 3008 coin cell retainer")
   (attr smd)
@@ -60,7 +60,7 @@
   (fp_line (start -3.8 -12.9) (end 3.8 -12.9) (layer F.Fab) (width 0.15))
   (pad 1 smd rect (at -15.3 0) (size 6 5.5) (layers F.Cu F.Paste F.Mask))
   (pad 1 smd rect (at 15.3 0) (size 6 5.5) (layers F.Cu F.Paste F.Mask))
-  (pad 2 smd rect (at 0 0) (size 8 8) (layers F.Cu F.Paste F.Mask))
+  (pad 2 smd rect (at 0 0) (size 8 8) (layers F.Cu F.Mask))
   (model Battery_Holders.3dshapes/Keystone_3008_1x2450-CoinCell.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))

--- a/Keystone_3009_1x2450-CoinCell.kicad_mod
+++ b/Keystone_3009_1x2450-CoinCell.kicad_mod
@@ -1,4 +1,4 @@
-(module Keystone_3009_1x2450-CoinCell (layer F.Cu) (tedit 57AF132A)
+(module Keystone_3009_1x2450-CoinCell (layer F.Cu) (tedit 58972349)
   (descr http://www.keyelco.com/product-pdf.cfm?p=787)
   (tags "Keystone type 3009 coin cell retainer")
   (fp_text reference REF*** (at 0 -14.4) (layer F.SilkS)
@@ -55,7 +55,7 @@
   (fp_line (start -4.45 -12.55) (end -13.35 -6.7) (layer F.CrtYd) (width 0.05))
   (pad 1 thru_hole circle (at -12.7 0) (size 3 3) (drill 1.9) (layers *.Cu *.Mask))
   (pad 1 thru_hole circle (at 12.7 0) (size 3 3) (drill 1.9) (layers *.Cu *.Mask))
-  (pad 2 smd rect (at 0 0) (size 8 8) (layers F.Cu F.Paste F.Mask))
+  (pad 2 smd rect (at 0 0) (size 8 8) (layers F.Cu F.Mask))
   (model Battery_Holders.3dshapes/Keystone_3009_1x2450-CoinCell.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))


### PR DESCRIPTION
The negative terminal of the coin cell clips is directly pushed towards the negative pole of the coin cell and thus needs no solder mask.